### PR TITLE
Adding ThemeLeaf XSD and fixed th:href

### DIFF
--- a/lab-9/gateway/src/main/resources/templates/sentence.html
+++ b/lab-9/gateway/src/main/resources/templates/sentence.html
@@ -1,7 +1,7 @@
-<html>
+<html xmlns:th="http://www.w3.org/1999/xhtml">
 <head>
 	<!-- Bootstrap CSS -->
-	<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css" />
+	<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css"
 		th:href="@{/css/bootstrap.min.css}" />
 </head>
 <body>


### PR DESCRIPTION
There was a typo with unused th:href inside of <link> element. 
Also it would be nice to specify XSD for Intellij Idea (and other IDEs) code completion for th: attributes.
Please merge this pull request.
