### PR TITLE
The mistake in the instruction for lab-9

### DIFF
--- a/LabInstructions/Lab 9.md
+++ b/LabInstructions/Lab 9.md
@@ -35,7 +35,7 @@
 
 9.  Stop the lab-9-gateway application.
 
-10.  Add the dependency for the config client.  org.springframework.cloud / spring-cloud-config-client.  
+10.  Add the dependency for the config client.  org.springframework.cloud / spring-cloud-starter-config.  
 
 11.  Add the dependency for Eureka-based service discovery.  org.springframework.cloud / spring-cloud-starter-netflix-eureka-client.
 


### PR DESCRIPTION
It was a typo where you explain which dependencies we need to add for using `zuul`. In your version, you write `spring-cloud-config-client` but we have to use `spring-cloud-starter-config` as we used before.